### PR TITLE
Add endpoint versioning support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -347,3 +347,11 @@ healthchecksdb
 
 # Backup folder for Package Reference Convert tool in Visual Studio 2017
 MigrationBackup/
+
+# Ignore only specific Rider files/directories
+/.idea/*
+!/.idea/.idea.*
+/.idea/.idea.*/*
+!/.idea/.idea.*/.idea
+/.idea/.idea.*/.idea/*
+!/.idea/.idea.*/.idea/runConfigurations

--- a/Src/Library/Endpoint.Setup.cs
+++ b/Src/Library/Endpoint.Setup.cs
@@ -241,4 +241,13 @@ public abstract partial class Endpoint<TRequest, TResponse> : BaseEndpoint where
     {
         Settings.Tags = endpointTags;
     }
+
+    /// <summary>
+    /// if versioning is set up, specify the version value of the endpoint.
+    /// </summary>
+    /// <param name="version">the version value to associate with this endpoint</param>
+    protected void Version(string version)
+    {
+        Settings.Version = version;
+    }
 }

--- a/Src/Library/EndpointSettings.cs
+++ b/Src/Library/EndpointSettings.cs
@@ -22,4 +22,5 @@ internal class EndpointSettings
     internal object? PostProcessors;
     internal ResponseCacheAttribute? ResponseCacheSettings;
     internal string[]? Tags;
+    internal string Version;
 }

--- a/Src/Library/Extensions/Config.cs
+++ b/Src/Library/Extensions/Config.cs
@@ -10,6 +10,7 @@ namespace FastEndpoints;
 public class Config
 {
     internal static JsonSerializerOptions serializerOptions { get; set; } = new(); //should only be set from UseFastEndpoints() during startup
+    internal static VersioningOptions versioningOptions { get; set; } = new();
     internal static Func<IEnumerable<ValidationFailure>, object> errorResponseBuilder { get; private set; } = failures => new ErrorResponse(failures);
     internal static Func<DiscoveredEndpoint, bool>? endpointRegistrationFilter { get; private set; }
 
@@ -17,6 +18,11 @@ public class Config
     /// settings for configuring the json serializer
     /// </summary>
     public Action<JsonSerializerOptions>? SerializerOptions { set => value?.Invoke(serializerOptions); }
+    
+    /// <summary>
+    /// settings to support versioning of the endpoints
+    /// </summary>
+    public Action<VersioningOptions>? VersioningOptions { set => value?.Invoke(versioningOptions); }
 
     /// <summary>
     /// a function for transforming validation errors to an error response dto.

--- a/Src/Library/Extensions/VersioningOptions.cs
+++ b/Src/Library/Extensions/VersioningOptions.cs
@@ -1,0 +1,17 @@
+namespace FastEndpoints;
+
+/// <summary>
+/// Endpoint versioning options.
+/// </summary>
+public class VersioningOptions
+{
+	/// <summary>
+	/// the prefix used in front of the version (for example 'v' produces 'v{version}').
+	/// </summary>
+	public string Prefix { get; set; }
+
+	/// <summary>
+	/// when the endpoint has no version value set, use this value as a default value.
+	/// </summary>
+	public string DefaultVersion { get; set; }
+}

--- a/Web/Program.cs
+++ b/Web/Program.cs
@@ -26,6 +26,11 @@ app.UseFastEndpoints(config =>
     config.SerializerOptions = o => o.PropertyNamingPolicy = null;
     config.EndpointRegistrationFilter = ep => ep.Tags?.Contains("exclude") is not true;
     //config.ErrorResponseBuilder = failures => $"there are {failures.Count()} validation issues!";
+    // config.VersioningOptions = o =>
+    // {
+    //     o.Prefix = "v";
+    //     o.DefaultVersion = "1"; 
+    // };
 });
 
 if (!app.Environment.IsProduction())


### PR DESCRIPTION
This PR adds an option to prefix each route with an (optional) version prefix and version value. At setup, a default version value can be set for all endpoints; in the configuration of the endpoint a specific version value can be set.

I tested this in the Test/Web projects.

However, I could not find a way to create a unit test for this, as adding this option in the `program.cs` of the Web project would change all endpoints.

Maybe it's an idea to try to see whether the `UseFastEndpoints` can be test-able. maybe by mocking the assembly scanner, a way that you can create test-endpoints in a test project and for specific tests (able to choose which set of endoints to use by the scanner).

If you have any suggestion for writing a test for this change, please let me know.