### PR TITLE
Add doc on how to model bind raw request content

### DIFF
--- a/Src/Documentation/wiki/Model-Binding.md
+++ b/Src/Documentation/wiki/Model-Binding.md
@@ -233,6 +233,21 @@ public class GetArticle : EndpointWithoutRequest
 Route<Point>("point", isRequired: false);
 ```
 
+## binding to raw request content
+if you need to access the raw request content as a string (i.e. you wan't to enqueue whathever was posted to your endpoint for later processing), your request dto must implement the interface `IPlainTextRequest`:
+
+```csharp
+public class Request : IPlainTextRequest
+{
+    /// <summary>
+    /// Request content.
+    /// </summary>
+    public string Content { get; set; }
+
+    // add other properties in case you need to access other values from route/query/etc.
+}
+```
+
 # json serialization casing
 by default the serializer uses **camel casing** for serializing/deserializing. you can change the casing as shown in the [configuration settings](Configuration-Settings.md#specify-json-serializer-options) section.
 


### PR DESCRIPTION
Adding documentation on how to bind to the raw request. I was going to try to implement something myself when I discovered the IPlainTextRequest interface already exists! Awesome! :)

I have just changed the Model-Binding.md file because I have no experience with the docfx. I have tried to run it but it changed a lot of files (not just version number, it changed the actual contents), so I am not sure if I am missing some command line arguments or doing something wrong. Please let me know if you want me to run it, and if so, what is the correct process.