### PR TITLE
add overload sendokasync to accept response body

### DIFF
--- a/Src/Library/Endpoint/Endpoint.Send.cs
+++ b/Src/Library/Endpoint/Endpoint.Send.cs
@@ -61,6 +61,17 @@ public abstract partial class Endpoint<TRequest, TResponse> : BaseEndpoint where
     }
 
     /// <summary>
+    /// send an http 200 ok response with the supplied response dto serialized as json to the client.
+    /// </summary>
+    /// <param name="response">the object to serialize to json</param>
+    /// <param name="cancellation">optional cancellation token</param>
+    protected Task SendOkAsync(TResponse response, CancellationToken cancellation = default)
+    {
+        Response = response;
+        return HttpContext.Response.SendOkAsync(response, Configuration.SerializerContext, cancellation);
+    }
+    
+    /// <summary>
     /// send an http 200 ok response without any body
     /// </summary>
     /// <param name="cancellation">optional cancellation token</param>

--- a/Src/Library/Extensions/HttpResponseExtensions.cs
+++ b/Src/Library/Extensions/HttpResponseExtensions.cs
@@ -82,6 +82,18 @@ public static class HttpResponseExtensions
         rsp.StatusCode = 200;
         return rsp.StartAsync(cancellation);
     }
+    
+    /// <summary>
+    /// send an http 200 ok response with the supplied response dto serialized as json to the client.
+    /// </summary>
+    /// <param name="response">the object to serialize to json</param>
+    /// <param name="jsonSerializerContext">json serializer context if code generation is used</param>
+    /// <param name="cancellation">optional cancellation token</param>
+    public static Task SendOkAsync<TResponse>(this HttpResponse rsp, TResponse response, JsonSerializerContext? jsonSerializerContext = null, CancellationToken cancellation = default) where TResponse : notnull
+    {
+        rsp.StatusCode = 200;
+        return RespSerializerFunc(rsp, response, "application/json", jsonSerializerContext, cancellation);
+    }
 
     /// <summary>
     /// send a 400 bad request with error details of the current validation failures


### PR DESCRIPTION
this allows an overload to SendOkAsync to take a body. similar to return Ok() and return Ok(response) that most .net devs would be familiar with.