### PR TITLE
Setting default swagger gen json serializer to camel case

### DIFF
--- a/Src/Swagger/Extensions.cs
+++ b/Src/Swagger/Extensions.cs
@@ -63,7 +63,7 @@ public static class Extensions
         services.AddEndpointsApiExplorer();
         services.AddOpenApiDocument(s =>
         {
-            var ser = new JsonSerializerSettings() { ContractResolver = new DefaultContractResolver { NamingStrategy = null } };
+            var ser = new JsonSerializerSettings() { ContractResolver = new CamelCasePropertyNamesContractResolver { NamingStrategy = null } };
             serializerSettings?.Invoke(ser);
             s.SerializerSettings = ser;
             s.EnableFastEndpoints(tagIndex, maxEndpointVersion, shortSchemaNames);


### PR DESCRIPTION
Swagger Gen default serializer is set to Pascal case. Setting this to camel case will be a better default.

To set this back to Pascal case you can instead use:

```csharp
builder.Services.AddSwaggerDoc(serializerSettings: x => x.ContractResolver = null);
```