### PR TITLE
Adding an overload to `Endpoint.SerializerContext`

### DIFF
--- a/Benchmark/FastEndpointsBench/CodeGenEndpoint.cs
+++ b/Benchmark/FastEndpointsBench/CodeGenEndpoint.cs
@@ -50,7 +50,7 @@ public class CodeGenEndpoint : Endpoint<CodeGenRequest, CodeGenResponse>
         Verbs(Http.POST);
         Routes("/benchmark/codegen/{id}");
         AllowAnonymous();
-        SerializerContext<SerializerCtx>();
+        SerializerContext(SerializerCtx.Default);
     }
 
     public override Task HandleAsync(CodeGenRequest req, CancellationToken ct)

--- a/Src/Library/Endpoint/Endpoint.Setup.cs
+++ b/Src/Library/Endpoint/Endpoint.Setup.cs
@@ -342,6 +342,7 @@ public abstract partial class Endpoint<TRequest, TResponse> : BaseEndpoint where
     /// specify the json serializer context if code generation for request/response dtos
     /// </summary>
     /// <typeparam name="TContext">the type of the json serializer context for this endpoint</typeparam>
+    [Obsolete("Use the SerializerContext<TContext>(TContext serializerContext) method")]
     protected void SerializerContext<TContext>() where TContext : JsonSerializerContext
     {
         Configuration.SerializerContext =
@@ -350,6 +351,15 @@ public abstract partial class Endpoint<TRequest, TResponse> : BaseEndpoint where
                 new JsonSerializerOptions(SerializerOpts))!;
     }
 
+    /// <summary>
+    /// specify the json serializer context if code generation for request/response dtos
+    /// </summary>
+    /// <typeparam name="TContext">the type of the json serializer context for this endpoint</typeparam>
+    protected void SerializerContext<TContext>(TContext serializerContext) where TContext : JsonSerializerContext
+    {
+        Configuration.SerializerContext = serializerContext;
+    }
+    
     /// <summary>
     /// register the validator for this endpoint as scoped instead of singleton. which will enable constructor injection at the cost of performance.
     /// </summary>

--- a/Web/[Features]/Admin/Login/Endpoint.cs
+++ b/Web/[Features]/Admin/Login/Endpoint.cs
@@ -34,7 +34,7 @@ public class Endpoint : Endpoint<Request, Response>
             s[403] = "forbidden when login fails";
             s[201] = "new resource created";
         });
-        SerializerContext<AdminLogin>();
+        SerializerContext(AdminLogin.Default);
     }
 
     public override Task HandleAsync(Request r, CancellationToken ct)


### PR DESCRIPTION
Adding an overload to `Endpoint.SerializerContext` that takes a specific instance of a `JsonSerializerContext` so the generated serialization code with be used (implements #67)

Not sure if the previous implementation should be marked `Obsolete` but that's what I did :)