### PR TITLE
Added Query<T> for consistency with Route<T>

### DIFF
--- a/Src/Library/Endpoint/Endpoint.cs
+++ b/Src/Library/Endpoint/Endpoint.cs
@@ -139,6 +139,36 @@ public abstract partial class Endpoint<TRequest, TResponse> : BaseEndpoint, ISer
 
         return default;// not required and retrieval failed
     }
+    
+    /// <summary>
+    /// get the value of a given query parameter by specifying the resulting type and query parameter name.
+    /// NOTE: an automatic validation error is sent to the client when value retrieval is not successful.
+    /// </summary>
+    /// <typeparam name="T">type of the result</typeparam>
+    /// <param name="queryParamName">query parameter name</param>
+    /// <param name="isRequired">set to false for disabling the automatic validation error</param>
+    /// <returns>the value if retrieval is successful or null if <paramref name="isRequired"/> is set to false</returns>
+    protected T? Query<T>(string queryParamName, bool isRequired = true)
+    {
+        if (HttpContext.Request.Query.TryGetValue(queryParamName, out var val))
+        {
+            var res = typeof(T).ValueParser()?.Invoke(val);
+
+            if (res?.isSuccess is true)
+                return (T?)res?.value;
+
+            if (isRequired)
+                ValidationFailures.Add(new(queryParamName, "Unable to read value of query parameter!"));
+        }
+        else if (isRequired)
+        {
+            ValidationFailures.Add(new(queryParamName, "Query parameter was not found!"));
+        }
+
+        ThrowIfAnyErrors();
+
+        return default;// not required and retrieval failed
+    }
 }
 
 /// <summary>

--- a/Test/MiscTestCases.cs
+++ b/Test/MiscTestCases.cs
@@ -397,5 +397,30 @@ namespace Test
             Assert.AreEqual(HttpStatusCode.OK, rsp.StatusCode);
             Assert.AreEqual("ok!", res.Message);
         }
+        
+        [TestMethod]
+        public async Task QueryParamReadingInEndpointWithoutRequest()
+        {
+            var (rsp, res) = await GuestClient.GETAsync<
+                EmptyRequest,
+                TestCases.RouteBindingInEpWithoutReq.Response>(
+                "/api/test-cases/ep-witout-req-query-param-binding-test?customerId=09809&otherId=12", new());
+
+            Assert.AreEqual(HttpStatusCode.OK, rsp?.StatusCode);
+            Assert.AreEqual(09809, res!.CustomerID);
+            Assert.AreEqual(12, res!.OtherID);
+        }
+
+        [TestMethod]
+        public async Task QueryParamReadingIsRequired()
+        {
+            var (rsp, res) = await GuestClient.GETAsync<
+                EmptyRequest,
+                ErrorResponse>(
+                "/api/test-cases/ep-witout-req-query-param-binding-test?customerId=09809&otherId=lkjhlkjh", new());
+
+            Assert.AreEqual(HttpStatusCode.BadRequest, rsp?.StatusCode);
+            Assert.IsTrue(res?.Errors.ContainsKey("OtherID"));
+        }
     }
 }

--- a/Web/[Features]/TestCases/QueryParamBindingInEpWithoutReq/EpWithoutReqQueryParamBindingTest.cs
+++ b/Web/[Features]/TestCases/QueryParamBindingInEpWithoutReq/EpWithoutReqQueryParamBindingTest.cs
@@ -1,0 +1,33 @@
+﻿namespace Web._Features_.TestCases.QueryParamBindingInEpWithoutReq;
+
+public class EpWithoutReqQueryParamBindingTest  : EndpointWithoutRequest<Response>
+{
+    public override void Configure()
+    {
+        Get("test-cases/ep-witout-req-query-param-binding-test");
+        AllowAnonymous();
+        Summary(s =>
+            s.Params["OtherID"] = "the description for other id");
+    }
+
+    public override Task HandleAsync(CancellationToken ct)
+    {
+        return SendAsync(new()
+        {
+            CustomerID = Query<int>("CustomerID"),
+            OtherID = Query<int>("OtherID")
+        });
+    }
+}
+
+public class Response
+{
+    [BindFrom("customerId")]
+    public int CustomerID { get; set; }
+
+    /// <summary>
+    /// optional other id
+    /// </summary>
+    [BindFrom("otherID")]
+    public int? OtherID { get; set; }
+}


### PR DESCRIPTION
Offers the same functionality as Route<T> just for query params