### PR TITLE
Added global settings for throttling

### DIFF
--- a/Src/Library/Config/Config.cs
+++ b/Src/Library/Config/Config.cs
@@ -17,6 +17,7 @@ public class Config
     internal static JsonSerializerOptions SerializerOpts { get; set; } = new(); //should only be set from UseFastEndpoints() during startup
     internal static bool ShortEpNames { get; private set; }
     internal static VersioningOptions? VersioningOpts { get; private set; }
+    internal static ThrottleOptions? ThrottleOpts { get; private set; }
     internal static RoutingOptions? RoutingOpts { get; private set; }
     internal static Func<EndpointDefinition, bool>? EpRegFilterFunc { get; private set; }
     internal static Action<EndpointDefinition, RouteHandlerBuilder>? GlobalEpOptsAction { get; private set; }
@@ -69,6 +70,18 @@ public class Config
         {
             RoutingOpts = new();
             value(RoutingOpts);
+        }
+    }
+    
+    /// <summary>
+    /// throttling options for all endpoints
+    /// </summary>
+    public Action<ThrottleOptions> ThrottleOptions
+    {
+        set
+        {
+            ThrottleOpts = new();
+            value(ThrottleOpts);
         }
     }
 

--- a/Src/Library/Config/ThrottleOptions.cs
+++ b/Src/Library/Config/ThrottleOptions.cs
@@ -1,0 +1,17 @@
+﻿namespace FastEndpoints;
+
+/// <summary>
+/// global settings for throttling
+/// </summary>
+public class ThrottleOptions
+{
+    /// <summary>
+    /// header used to track rate limits
+    /// </summary>
+    public string? HeaderName { get; set; }
+
+    /// <summary>
+    /// custom error response for throttled requests
+    /// </summary>
+    public string? ThrottledResponse { get; set; }
+}

--- a/Src/Library/Extensions/ExecutorMiddleware.cs
+++ b/Src/Library/Extensions/ExecutorMiddleware.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
+using static FastEndpoints.Config;
 
 namespace FastEndpoints;
 
@@ -34,7 +35,7 @@ internal class ExecutorMiddleware
 
             if (epDef.HitCounter is not null)
             {
-                var hdrName = epDef.HitCounter.HeaderName ?? "X-Forwarded-For";
+                var hdrName = epDef.HitCounter.HeaderName ?? ThrottleOpts?.HeaderName ?? "X-Forwarded-For";
 
                 if (!ctx.Request.Headers.TryGetValue(hdrName, out var hdrVal))
                 {
@@ -50,7 +51,9 @@ internal class ExecutorMiddleware
                 if (epDef.HitCounter.LimitReached(hdrVal[0]))
                 {
                     ctx.Response.StatusCode = 429;
-                    return ctx.Response.WriteAsync("You are requesting this endpoint too frequently!");
+
+                    var response = ThrottleOpts?.ThrottledResponse ?? "You are requesting this endpoint too frequently!";
+                    return ctx.Response.WriteAsync(response);
                 }
             }
 

--- a/Test/AdminTests.cs
+++ b/Test/AdminTests.cs
@@ -61,7 +61,7 @@ namespace Test
         public async Task AdminLoginThrottling()
         {
             var guestClient = new WebApplicationFactory<Program>().CreateClient();
-            guestClient.DefaultRequestHeaders.Add("X-Forwarded-For", "TEST");
+            guestClient.DefaultRequestHeaders.Add("X-Custom-Throttle-Header", "TEST");
 
             int successCount = 0;
 

--- a/Test/MiscTestCases.cs
+++ b/Test/MiscTestCases.cs
@@ -428,13 +428,13 @@ namespace Test
         {
             HttpResponseMessage? response = null;
 
-            for( int i = 0; i < 5; i++ )
+            for(int i = 0; i < 5; i++)
             {
                 var request = new HttpRequestMessage();
                 request.Method = HttpMethod.Get;
-                request.Headers.Add( "X-Custom-Throttle-Header", "test" );
-                request.RequestUri = new Uri( "api/test-cases/global-throttle-error-response?customerId=09809&otherId=12", UriKind.Relative );
-                response = await GuestClient.SendAsync( request );
+                request.Headers.Add("X-Custom-Throttle-Header", "test");
+                request.RequestUri = new Uri("api/test-cases/global-throttle-error-response?customerId=09809&otherId=12", UriKind.Relative);
+                response = await GuestClient.SendAsync(request);
             }
             
             Assert.AreEqual(HttpStatusCode.TooManyRequests, response!.StatusCode);
@@ -448,13 +448,13 @@ namespace Test
         {
             HttpResponseMessage? response = null;
 
-            for( int i = 0; i < 3; i++ )
+            for(int i = 0; i < 3; i++)
             {
                 var request = new HttpRequestMessage();
                 request.Method = HttpMethod.Get;
-                request.Headers.Add( "X-Custom-Throttle-Header", "test-2" );
-                request.RequestUri = new Uri( "api/test-cases/global-throttle-error-response?customerId=09809&otherId=12", UriKind.Relative );
-                response = await GuestClient.SendAsync( request );
+                request.Headers.Add("X-Custom-Throttle-Header", "test-2");
+                request.RequestUri = new Uri("api/test-cases/global-throttle-error-response?customerId=09809&otherId=12", UriKind.Relative);
+                response = await GuestClient.SendAsync(request);
             }
             
             Assert.AreEqual(HttpStatusCode.OK, response!.StatusCode);

--- a/Test/MiscTestCases.cs
+++ b/Test/MiscTestCases.cs
@@ -422,5 +422,42 @@ namespace Test
             Assert.AreEqual(HttpStatusCode.BadRequest, rsp?.StatusCode);
             Assert.IsTrue(res?.Errors.ContainsKey("OtherID"));
         }
+
+        [TestMethod]
+        public async Task ThrottledGlobalResponse()
+        {
+            HttpResponseMessage? response = null;
+
+            for( int i = 0; i < 5; i++ )
+            {
+                var request = new HttpRequestMessage();
+                request.Method = HttpMethod.Get;
+                request.Headers.Add( "X-Custom-Throttle-Header", "test" );
+                request.RequestUri = new Uri( "api/test-cases/global-throttle-error-response?customerId=09809&otherId=12", UriKind.Relative );
+                response = await GuestClient.SendAsync( request );
+            }
+            
+            Assert.AreEqual(HttpStatusCode.TooManyRequests, response!.StatusCode);
+            
+            var responseContent = await response!.Content.ReadAsStringAsync();
+            Assert.AreEqual(responseContent, "Custom Error Response");
+        }
+        
+        [TestMethod]
+        public async Task NotThrottledGlobalResponse()
+        {
+            HttpResponseMessage? response = null;
+
+            for( int i = 0; i < 3; i++ )
+            {
+                var request = new HttpRequestMessage();
+                request.Method = HttpMethod.Get;
+                request.Headers.Add( "X-Custom-Throttle-Header", "test-2" );
+                request.RequestUri = new Uri( "api/test-cases/global-throttle-error-response?customerId=09809&otherId=12", UriKind.Relative );
+                response = await GuestClient.SendAsync( request );
+            }
+            
+            Assert.AreEqual(HttpStatusCode.OK, response!.StatusCode);
+        }
     }
 }

--- a/Web/Program.cs
+++ b/Web/Program.cs
@@ -82,6 +82,11 @@ app.UseFastEndpoints(config =>
         //o.DefaultVersion = 1; 
         //o.SuffixedVersion = false; 
     };
+    config.ThrottleOptions = o =>
+    {
+        o.HeaderName = "X-Custom-Throttle-Header";
+        o.ThrottledResponse = "Custom Error Response";
+    };
 });
 
 //this must go after usefastendpoints (only if using endpoints)

--- a/Web/[Features]/TestCases/RateLimitTests/GlobalErrorResponseTest.cs
+++ b/Web/[Features]/TestCases/RateLimitTests/GlobalErrorResponseTest.cs
@@ -1,0 +1,22 @@
+﻿namespace TestCases.RateLimitTests;
+
+public class GlobalErrorResponseTest : EndpointWithoutRequest<Response>
+{
+    public override void Configure()
+    {
+        Get("test-cases/global-throttle-error-response");
+        AllowAnonymous();
+        Summary(s =>
+            s.Params["OtherID"] = "the description for other id");
+        Throttle(3, 120);
+    }
+
+    public override Task HandleAsync(CancellationToken ct)
+    {
+        return SendAsync(new()
+        {
+            CustomerID = Query<int>("CustomerID"),
+            OtherID = Query<int>("OtherID")
+        });
+    }
+}

--- a/Web/[Features]/TestCases/RateLimitTests/Models.cs
+++ b/Web/[Features]/TestCases/RateLimitTests/Models.cs
@@ -1,0 +1,13 @@
+﻿namespace TestCases.RateLimitTests;
+
+public class Response
+{
+    [BindFrom("customerId")]
+    public int CustomerID { get; set; }
+
+    /// <summary>
+    /// optional other id
+    /// </summary>
+    [BindFrom("otherID")]
+    public int? OtherID { get; set; }
+}


### PR DESCRIPTION
Ability to set a global header name for all endpoints & a custom response.
Global header is overwritten by any headers set in Throttle() per request. If neither is set falls back to default of "X-Forwarded-For"
If no custom response is set it falls back to "You are requesting this endpoint too frequently!"