### PR TITLE
Scan parents for generic arguments of specific base types

### DIFF
--- a/Src/Library/Extensions/EndpointData.cs
+++ b/Src/Library/Extensions/EndpointData.cs
@@ -81,10 +81,7 @@ internal sealed class EndpointData
             {
                 if (tInterface == Types.IEndpoint)
                 {
-                    var tRequest = Types.EmptyRequest;
-
-                    if (tDisc.BaseType?.IsGenericType is true)
-                        tRequest = tDisc.BaseType?.GetGenericArguments()?[0] ?? tRequest;
+                    var tRequest = tDisc.GetGenericArgumentsOfType(Types.Endpoint)?[0] ?? Types.EmptyRequest;
 
                     services.AddTransient(tDisc);
                     epList.Add((tDisc, tRequest));
@@ -93,7 +90,7 @@ internal sealed class EndpointData
 
                 if (tInterface == Types.IValidator)
                 {
-                    Type tRequest = tDisc.BaseType?.GetGenericArguments()[0]!;
+                    Type tRequest = tDisc.GetGenericArgumentsOfType(Types.Validator)?[0]!;
                     valDict.Add(tRequest, tDisc);
                     continue;
                 }

--- a/Src/Library/Extensions/ReflectionExtensions.cs
+++ b/Src/Library/Extensions/ReflectionExtensions.cs
@@ -37,6 +37,23 @@ internal static class ReflectionExtensions
         return Expression.Lambda<Action<object, object>>(body, parent, value).Compile();
     }
 
+    internal static Type[]? GetGenericArgumentsOfType(this Type source, Type targetGeneric)
+    {
+        if (!targetGeneric.IsGenericType)
+            throw new ArgumentException($"{nameof(targetGeneric)} is not a valid generic type", nameof(targetGeneric));
+
+        var t = source;
+        while (t != null)
+        {
+            if (t.IsGenericType && t.GetGenericTypeDefinition() == targetGeneric)
+                return t.GetGenericArguments();
+
+            t = t.BaseType;
+        }
+
+        return null;
+    }
+
     private static readonly ConcurrentDictionary<Type, Func<object?, (bool isSuccess, object value)>?> parsers = new();
     internal static Func<object?, (bool isSuccess, object value)>? ValueParser(this Type type)
     {

--- a/Src/Library/Types.cs
+++ b/Src/Library/Types.cs
@@ -16,11 +16,13 @@ internal static class Types
     internal static readonly Type Guid = typeof(Guid);
     internal static readonly Type Http = typeof(Http);
     internal static readonly Type IEndpoint = typeof(IEndpoint);
+    internal static readonly Type Endpoint = typeof(Endpoint<,>);
     internal static readonly Type IEndpointFeature = typeof(IEndpointFeature);
     internal static readonly Type IEventHandler = typeof(IEventHandler);
     internal static readonly Type IFormFile = typeof(IFormFile);
     internal static readonly Type IPlainTextRequest = typeof(IPlainTextRequest);
     internal static readonly Type IValidator = typeof(IValidator);
+    internal static readonly Type Validator = typeof(AbstractValidator<>);
     internal static readonly Type NotImplementedAttribute = typeof(NotImplementedAttribute);
     internal static readonly Type Object = typeof(object);
     internal static readonly Type QueryParamAttribute = typeof(QueryParamAttribute);


### PR DESCRIPTION
Resolves https://github.com/dj-nitehawk/FastEndpoints/issues/94

Rather than just going up one level to grab the `BaseType`, it will now go up the inheritance chain until it finds the relevant generic types to ensure it's grabbing the correct type param.