### PR TITLE
Log the entire exception

### DIFF
--- a/Src/Library/Extensions/ExceptionHandlerExtensions.cs
+++ b/Src/Library/Extensions/ExceptionHandlerExtensions.cs
@@ -39,7 +39,7 @@ $@"=================================
 TYPE: {type}
 REASON: {error}
 ---------------------------------
-{exHandlerFeature.Error.StackTrace}";
+{exHandlerFeature.Error}";
 
                     logger ??= ctx.RequestServices.GetRequiredService<ILogger<ExceptionHandler>>();
                     logger.LogError(msg);


### PR DESCRIPTION
Logging the entire exception enables tools like serilog.exceptions to enrich exceptions.