### PR TITLE
Added structured logging to the ExceptionHandler

### DIFF
--- a/Src/Library/Extensions/ExceptionHandlerExtensions.cs
+++ b/Src/Library/Extensions/ExceptionHandlerExtensions.cs
@@ -40,12 +40,12 @@ public static class ExceptionHandlerExtensions
 
                     if (logEntireException)
                     {
-                        logger.LogError("================================={@HTTP}{@TYPE}{@REASON}{@EXCEPTION}",http,type,error,exHandlerFeature.Error);
+                        logger.LogError("================================={@http}{@type}{@reason}{@exception}",http,type,error,exHandlerFeature.Error);
 
                     }
                     else
                     {
-                        logger.LogError("================================={@HTTP}{@TYPE}{@REASON}{@STACKTRACE}", http,
+                        logger.LogError("================================={@http}{@type}{@reason}{@stackTrace}", http,
                             type, error, exHandlerFeature.Error.StackTrace);
                     }
                     ctx.Response.StatusCode = (int)HttpStatusCode.InternalServerError;

--- a/Src/Library/Extensions/ExceptionHandlerExtensions.cs
+++ b/Src/Library/Extensions/ExceptionHandlerExtensions.cs
@@ -22,7 +22,8 @@ public static class ExceptionHandlerExtensions
     /// </code>
     /// </summary>
     /// <param name="logger">an optional logger instance</param>
-    public static void UseDefaultExceptionHandler(this IApplicationBuilder app, ILogger? logger = null, bool logEntireException = false)
+    public static void UseDefaultExceptionHandler(this IApplicationBuilder app, ILogger? logger = null,
+        bool logEntireException = false)
     {
         app.UseExceptionHandler(errApp =>
         {
@@ -35,20 +36,21 @@ public static class ExceptionHandlerExtensions
                     var error = exHandlerFeature.Error.Message;
 
                     var http = exHandlerFeature.Endpoint?.DisplayName?.Split(" => ")[0];
-                    
+
                     logger ??= ctx.RequestServices.GetRequiredService<ILogger<ExceptionHandler>>();
 
                     if (logEntireException)
                     {
-                        logger.LogError("================================={@http}{@type}{@reason}{@exception}",http,type,error,exHandlerFeature.Error);
-
+                        logger.LogError("================================={@http}{@type}{@reason}{@exception}",
+                            http, type, error, exHandlerFeature.Error);
                     }
                     else
                     {
-                        logger.LogError("================================={@http}{@type}{@reason}{@stackTrace}", http,
-                            type, error, exHandlerFeature.Error.StackTrace);
+                        logger.LogError("================================={@http}{@type}{@reason}{@stackTrace}",
+                            http, type, error, exHandlerFeature.Error.StackTrace);
                     }
-                    ctx.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
+
+                    ctx.Response.StatusCode = (int) HttpStatusCode.InternalServerError;
                     ctx.Response.ContentType = "application/problem+json";
                     await ctx.Response.WriteAsJsonAsync(new
                     {


### PR DESCRIPTION
Currently the exception handler does not log structurally.
![image](https://user-images.githubusercontent.com/96931708/166830359-ccaa0618-48fa-4746-a538-9e87d90cf705.png)


The changes to this pull request allows structured output for the exceptions captured in this logger. 

Here is an example of the stracktrace path 

![image](https://user-images.githubusercontent.com/96931708/166832128-ad0e2249-fcca-48d8-aa16-8757837fe698.png)

Here is an example of the exception path

![image](https://user-images.githubusercontent.com/96931708/166830724-5d7e5082-9777-4a51-a4aa-5e552822dab7.png)

Both cases are structured logged, enabling tools like [serilog.exceptions](https://github.com/RehanSaeed/Serilog.Exceptions) to output clear errors. 

Or at least see and enable user to search against the exceptions using params i.e. stacktrace or exception depending on the path instead of a blob of text.
