### PR TITLE
Add fluent validation rules into swagger spec

### DIFF
--- a/Src/Swagger/Extensions.cs
+++ b/Src/Swagger/Extensions.cs
@@ -29,6 +29,7 @@ public static class Extensions
     {
         settings.Title = AppDomain.CurrentDomain.FriendlyName;
         settings.SchemaNameGenerator = new SchemaNameGenerator(shortSchemaNames);
+        settings.SchemaProcessors.Add(new ValidationSchemaProcessor());
         settings.OperationProcessors.Add(new OperationProcessor(tagIndex));
         settings.DocumentProcessors.Add(new DocumentProcessor(maxEndpointVersion));
     }

--- a/Src/Swagger/FastEndpoints.Swagger.csproj
+++ b/Src/Swagger/FastEndpoints.Swagger.csproj
@@ -23,7 +23,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
         <PackageReference Include="NSwag.AspNetCore" Version="13.15.10" />
         <ProjectReference Include="..\Library\FastEndpoints.csproj" />
     </ItemGroup>

--- a/Src/Swagger/ValidationProcessor/Extensions/ReflectionExtensions.cs
+++ b/Src/Swagger/ValidationProcessor/Extensions/ReflectionExtensions.cs
@@ -1,0 +1,81 @@
+﻿using System.Reflection;
+
+namespace FastEndpoints.Swagger.ValidationProcessor.Extensions;
+
+internal static class ReflectionExtension
+{
+    /// <summary>
+    /// Is sub class of generic type
+    /// </summary>
+    /// <param name="child"></param>
+    /// <param name="parent"></param>
+    /// <returns></returns>
+    internal static bool IsSubClassOfGeneric(this Type child, Type parent)
+    {
+        if (child == parent)
+            return false;
+
+        if (child.IsSubclassOf(parent))
+            return true;
+
+        var parameters = parent.GetGenericArguments();
+
+        var isParameterLessGeneric = !(parameters is { Length: > 0 } &&
+                                       (parameters[0].Attributes & TypeAttributes.BeforeFieldInit) == TypeAttributes.BeforeFieldInit);
+
+        while (child != null && child != typeof(object))
+        {
+            var cur = GetFullTypeDefinition(child);
+
+            if (parent == cur || (isParameterLessGeneric && cur.GetInterfaces()
+                                                               .Select(GetFullTypeDefinition)
+                                                               .Contains(GetFullTypeDefinition(parent))))
+                return true;
+
+            if (!isParameterLessGeneric)
+            {
+                if (GetFullTypeDefinition(parent) == cur && !cur.IsInterface)
+                {
+                    if (VerifyGenericArguments(GetFullTypeDefinition(parent), cur))
+                        if (VerifyGenericArguments(parent, child))
+                            return true;
+                }
+                else
+                {
+                    if (child.GetInterfaces()
+                             .Where(i => GetFullTypeDefinition(parent) == GetFullTypeDefinition(i))
+                             .Any(item => VerifyGenericArguments(parent, item)))
+                        return true;
+                }
+            }
+
+            child = child.BaseType;
+        }
+
+        return false;
+    }
+
+    private static Type GetFullTypeDefinition(Type type) => type.IsGenericType ? type.GetGenericTypeDefinition() : type;
+
+    private static bool VerifyGenericArguments(Type parent, Type child)
+    {
+        var childArguments = child.GetGenericArguments();
+        var parentArguments = parent.GetGenericArguments();
+
+        if (childArguments.Length != parentArguments.Length)
+            return true;
+
+        for (var i = 0; i < childArguments.Length; i++)
+        {
+            if (childArguments[i].Assembly == parentArguments[i].Assembly &&
+                childArguments[i].Name == parentArguments[i].Name &&
+                childArguments[i].Namespace == parentArguments[i].Namespace)
+                continue;
+
+            if (!childArguments[i].IsSubclassOf(parentArguments[i]))
+                return false;
+        }
+
+        return true;
+    }
+}

--- a/Src/Swagger/ValidationProcessor/Extensions/StringExtensions.cs
+++ b/Src/Swagger/ValidationProcessor/Extensions/StringExtensions.cs
@@ -1,0 +1,140 @@
+﻿// Original: https://github.com/zymlabs/nswag-fluentvalidation
+// MIT License
+// Copyright (c) 2019 Zym Labs LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+//         of this software and associated documentation files (the "Software"), to deal
+//         in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+//         furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+//         copies or substantial portions of the Software.
+//
+//         THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//         IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//                                                                 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//         AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//         LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace FastEndpoints.Swagger.ValidationProcessor.Extensions;
+
+internal static class StringExtensions
+{
+    /// <summary>
+    /// Converts string to lowerCamelCase.
+    /// </summary>
+    /// <param name="inputString">Input string.</param>
+    /// <returns>lowerCamelCase string.</returns>
+    internal static string? ToLowerCamelCase(this string? inputString)
+    {
+        switch (inputString)
+        {
+            case null:
+                return null;
+            case "":
+                return string.Empty;
+        }
+
+        if (char.IsLower(inputString[0]))
+            return inputString;
+
+        return inputString[..1].ToLower() + inputString[1..];
+    }
+
+    /// <summary>
+    /// Returns string equality only by symbols ignore case.
+    /// It can be used for comparing camelCase, PascalCase, snake_case, kebab-case identifiers.
+    /// </summary>
+    /// <param name="left">Left string to compare.</param>
+    /// <param name="right">Right string to compare.</param>
+    /// <returns><c>true</c> if input strings are equals in terms of identifier formatting.</returns>
+    internal static bool EqualsIgnoreAll(this string left, string right) => IgnoreAllStringComparer.Instance.Equals(left, right);
+}
+
+/// <summary>
+/// Returns string equality only by symbols ignore case.
+/// It can be used for comparing camelCase, PascalCase, snake_case, kebab-case identifiers.
+/// </summary>
+internal class IgnoreAllStringComparer : StringComparer
+{
+    /// <summary>
+    /// Instance of StringComparer
+    /// </summary>
+    public static readonly StringComparer Instance = new IgnoreAllStringComparer();
+
+    /// <inheritdoc />
+    public override int Compare(string left, string right)
+    {
+        var leftIndex = 0;
+        var rightIndex = 0;
+        var compare = 0;
+        while (true)
+        {
+            GetNextSymbol(left, ref leftIndex, out var leftSymbol);
+            GetNextSymbol(right, ref rightIndex, out var rightSymbol);
+
+            compare = leftSymbol.CompareTo(rightSymbol);
+            if (compare != 0 || leftIndex < 0 || rightIndex < 0)
+                break;
+        }
+
+        return compare;
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(string left, string right)
+    {
+        if (left == null || right == null)
+            return false;
+
+        var leftIndex = 0;
+        var rightIndex = 0;
+        bool equals;
+        while (true)
+        {
+            var hasLeftSymbol = GetNextSymbol(left, ref leftIndex, out var leftSymbol);
+            var hasRightSymbol = GetNextSymbol(right, ref rightIndex, out var rightSymbol);
+
+            equals = leftSymbol == rightSymbol;
+            if (!equals || !hasLeftSymbol || !hasRightSymbol)
+                break;
+        }
+
+        return equals;
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode(string obj)
+    {
+        unchecked
+        {
+            var index = 0;
+            var hash = 0;
+            while (GetNextSymbol(obj, ref index, out var symbol))
+                hash = (31 * hash) + char.ToUpperInvariant(symbol).GetHashCode();
+
+            return hash;
+        }
+    }
+
+    internal static bool GetNextSymbol(string value, ref int startIndex, out char symbol)
+    {
+        while (startIndex >= 0 && startIndex < value.Length)
+        {
+            var current = value[startIndex++];
+            if (char.IsLetterOrDigit(current))
+            {
+                symbol = char.ToUpperInvariant(current);
+                return true;
+            }
+        }
+
+        startIndex = -1;
+        symbol = char.MinValue;
+        return false;
+    }
+}

--- a/Src/Swagger/ValidationProcessor/Extensions/ValidationExtensions.cs
+++ b/Src/Swagger/ValidationProcessor/Extensions/ValidationExtensions.cs
@@ -1,0 +1,123 @@
+﻿// Original: https://github.com/zymlabs/nswag-fluentvalidation
+// MIT License
+// Copyright (c) 2019 Zym Labs LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+//         of this software and associated documentation files (the "Software"), to deal
+//         in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+//         furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+//         copies or substantial portions of the Software.
+//
+//         THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//         IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//                                                                 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//         AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//         LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using FluentValidation;
+using FluentValidation.Validators;
+
+namespace FastEndpoints.Swagger.ValidationProcessor.Extensions;
+
+/// <summary>
+/// Extensions for some swagger specific work.
+/// </summary>
+internal static class ValidationExtensions
+{
+    /// <summary>
+    /// Is supported swagger numeric type.
+    /// </summary>
+    public static bool IsNumeric(this object value) => value is int or long or float or double or decimal;
+
+    /// <summary>
+    /// Returns not null enumeration.
+    /// </summary>
+    public static IEnumerable<TValue> NotNull<TValue>(this IEnumerable<TValue>? collection) => collection ?? Array.Empty<TValue>();
+
+    /// <summary>
+    /// Returns validation rules by property name ignoring name case.
+    /// </summary>
+    /// <param name="validator">Validator</param>
+    /// <param name="name">Property name.</param>
+    /// <returns>enumeration.</returns>
+    public static IEnumerable<ValidationRuleContext> GetValidationRulesForMemberIgnoreCase(this IValidator validator, string name) =>
+            (validator as IEnumerable<IValidationRule>)
+            .NotNull()
+            .GetPropertyRules()
+            .Where(validationRuleContext => HasNoCondition(validationRuleContext.ValidationRule) &&
+                                            validationRuleContext.ValidationRule.PropertyName.EqualsIgnoreAll(name));
+
+    /// <summary>
+    /// Returns property validators by property name ignoring name case.
+    /// </summary>
+    /// <param name="validator">Validator</param>
+    /// <param name="name">Property name.</param>
+    /// <returns>enumeration.</returns>
+    public static IEnumerable<IPropertyValidator> GetValidatorsForMemberIgnoreCase(this IValidator validator, string name) =>
+            GetValidationRulesForMemberIgnoreCase(validator, name)
+                    .SelectMany(
+                                validationRuleContext =>
+                                {
+                                    return validationRuleContext.ValidationRule.Components.Select(c => c.Validator);
+                                });
+
+    /// <summary>
+    /// Returns all IValidationRules that are PropertyRule.
+    /// If rule is CollectionPropertyRule then isCollectionRule set to true.
+    /// </summary>
+    internal static IEnumerable<ValidationRuleContext> GetPropertyRules(
+            this IEnumerable<IValidationRule> validationRules)
+    {
+        foreach (var validationRule in validationRules)
+        {
+            var isCollectionRule = validationRule.GetType() == typeof(ICollectionRule<,>);
+            yield return new ValidationRuleContext(validationRule, isCollectionRule);
+        }
+    }
+
+    // /// <summary>
+    // /// Returns a <see cref="bool"/> indicating if the <paramref name="propertyValidator"/> is conditional.
+    // /// </summary>
+    // internal static bool HasNoCondition(this IPropertyValidator propertyValidator)
+    // {
+    //     return propertyValidator?.Options?.Condition == null && propertyValidator?.Options?.AsyncCondition == null;
+    // }
+
+    /// <summary>
+    /// Returns a <see cref="bool"/> indicating if the <paramref name="propertyRule"/> is conditional.
+    /// </summary>
+    internal static bool HasNoCondition(this IValidationRule propertyRule) => !propertyRule.HasCondition && !propertyRule.HasAsyncCondition;
+
+    /// <summary>
+    /// Contains <see cref="IValidationRule"/> and additional info.
+    /// </summary>
+    public readonly struct ValidationRuleContext
+    {
+        /// <summary>
+        /// PropertyRule.
+        /// </summary>
+        public readonly IValidationRule ValidationRule;
+
+        /// <summary>
+        /// Flag indication whether the <see cref="IValidationRule"/> is the CollectionRule.
+        /// </summary>
+        public readonly bool IsCollectionRule;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValidationRuleContext"/> struct.
+        /// </summary>
+        /// <param name="validationRule">PropertyRule.</param>
+        /// <param name="isCollectionRule">Is a CollectionPropertyRule.</param>
+        public ValidationRuleContext(IValidationRule validationRule, bool isCollectionRule)
+        {
+            ValidationRule = validationRule;
+            IsCollectionRule = isCollectionRule;
+        }
+    }
+}

--- a/Src/Swagger/ValidationProcessor/FluentValidationRule.cs
+++ b/Src/Swagger/ValidationProcessor/FluentValidationRule.cs
@@ -1,0 +1,50 @@
+﻿// Original: https://github.com/zymlabs/nswag-fluentvalidation
+// MIT License
+// Copyright (c) 2019 Zym Labs LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+//         of this software and associated documentation files (the "Software"), to deal
+//         in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+//         furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+//         copies or substantial portions of the Software.
+//
+//         THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//         IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//                                                                 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//         AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//         LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using FluentValidation.Validators;
+
+namespace FastEndpoints.Swagger.ValidationProcessor;
+
+public class FluentValidationRule
+{
+    /// <summary>
+    /// Rule name.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// Predicate to match property validator.
+    /// </summary>
+    public Func<IPropertyValidator, bool> Matches { get; set; } = _ => false;
+
+    /// <summary>
+    /// Modify Swagger schema action.
+    /// </summary>
+    public Action<RuleContext> Apply { get; set; } = _ =>
+    {
+    };
+
+    public FluentValidationRule(string name)
+    {
+        Name = name;
+    }
+}

--- a/Src/Swagger/ValidationProcessor/RuleContext.cs
+++ b/Src/Swagger/ValidationProcessor/RuleContext.cs
@@ -1,0 +1,42 @@
+﻿// Original: https://github.com/zymlabs/nswag-fluentvalidation
+// MIT License
+// Copyright (c) 2019 Zym Labs LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+//         of this software and associated documentation files (the "Software"), to deal
+//         in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+//         furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+//         copies or substantial portions of the Software.
+//
+//         THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//         IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//                                                                 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//         AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//         LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using FluentValidation.Validators;
+using NJsonSchema.Generation;
+
+namespace FastEndpoints.Swagger.ValidationProcessor;
+
+public class RuleContext
+{
+    public SchemaProcessorContext SchemaProcessorContext { get; }
+
+    public string PropertyKey { get; }
+
+    public IPropertyValidator PropertyValidator { get; }
+
+    public RuleContext(SchemaProcessorContext schemaProcessorContext, string propertyKey, IPropertyValidator propertyValidator)
+    {
+        SchemaProcessorContext = schemaProcessorContext;
+        PropertyKey = propertyKey;
+        PropertyValidator = propertyValidator;
+    }
+}

--- a/Src/Swagger/ValidationSchemaProcessor.cs
+++ b/Src/Swagger/ValidationSchemaProcessor.cs
@@ -1,0 +1,249 @@
+﻿// Original: https://github.com/zymlabs/nswag-fluentvalidation
+// MIT License
+// Copyright (c) 2019 Zym Labs LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+//         of this software and associated documentation files (the "Software"), to deal
+//         in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+//         furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+//         copies or substantial portions of the Software.
+//
+//         THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//         IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//                                                                 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//         AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//         LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using FastEndpoints.Swagger.ValidationProcessor;
+using FastEndpoints.Swagger.ValidationProcessor.Extensions;
+using FluentValidation;
+using FluentValidation.Validators;
+using NJsonSchema;
+using NJsonSchema.Generation;
+using System.Reflection;
+
+namespace FastEndpoints.Swagger;
+
+public class ValidationSchemaProcessor : ISchemaProcessor
+{
+    private readonly FluentValidationRule[] _rules;
+
+    public ValidationSchemaProcessor()
+    {
+        _rules = CreateDefaultRules();
+    }
+
+    public void Process(SchemaProcessorContext context)
+    {
+        if (!context.Schema.IsObject || context.Schema.Properties.Count == 0)
+            return;
+
+        var type = context.Type;
+
+        var validatorType = Assembly.GetAssembly(type).DefinedTypes
+                                    .FirstOrDefault(x => x.ImplementedInterfaces.Contains(typeof(IValidator)) &&
+                                                         x.BaseType.GenericTypeArguments.Contains(type));
+        if (validatorType is null)
+            return;
+
+        try
+        {
+            var validator = Activator.CreateInstance(validatorType) as IValidator;
+            ApplyRulesToSchema(context, validator);
+        }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine(e);
+
+            //TODO:
+        }
+    }
+
+    private void ApplyRulesToSchema(SchemaProcessorContext context, IValidator validator)
+    {
+        var schema = context.Schema;
+        var schemaProperties = schema?.Properties?.Keys ?? Array.Empty<string>();
+        foreach (var schemaProperty in schemaProperties)
+            TryApplyValidation(context, validator, schemaProperty);
+    }
+
+    private void TryApplyValidation(SchemaProcessorContext context, IValidator validator, string schemaProperty)
+    {
+        var validators = validator.GetValidatorsForMemberIgnoreCase(schemaProperty);
+        foreach (var propertyValidator in validators)
+        foreach (var rule in _rules)
+        {
+            if (!rule.Matches(propertyValidator))
+                continue;
+
+            try
+            {
+                rule.Apply(new RuleContext(context, schemaProperty, propertyValidator));
+            }
+            catch (Exception e)
+            {
+            }
+        }
+    }
+
+    private static FluentValidationRule[] CreateDefaultRules() =>
+            new[] {
+                new FluentValidationRule("Required") {
+                    Matches = propertyValidator => propertyValidator is INotNullValidator or INotEmptyValidator,
+                    Apply = context =>
+                    {
+                        var schema = context.SchemaProcessorContext.Schema;
+
+                        if (schema == null)
+                            return;
+
+                        if (!schema.RequiredProperties.Contains(context.PropertyKey))
+                            schema.RequiredProperties.Add(context.PropertyKey);
+                    }
+                },
+                new FluentValidationRule("NotNull") {
+                    Matches = propertyValidator => propertyValidator is INotNullValidator,
+                    Apply = context =>
+                    {
+                        var schema = context.SchemaProcessorContext.Schema;
+
+                        schema.Properties[context.PropertyKey].IsNullableRaw = false;
+
+                        if (schema.Properties[context.PropertyKey].Type.HasFlag(JsonObjectType.Null))
+                            schema.Properties[context.PropertyKey].Type &= ~JsonObjectType.Null; // Remove nullable
+
+                        var oneOfsWithReference = schema.Properties[context.PropertyKey].OneOf
+                                                        .Where(x => x.Reference != null)
+                                                        .ToList();
+
+                        if (oneOfsWithReference.Count == 1)
+                        {
+                            // Set the Reference directly instead and clear the OneOf collection
+                            schema.Properties[context.PropertyKey].Reference = oneOfsWithReference.Single();
+                            schema.Properties[context.PropertyKey].OneOf.Clear();
+                        }
+                    }
+                },
+                new FluentValidationRule("NotEmpty") {
+                    Matches = propertyValidator => propertyValidator is INotEmptyValidator,
+                    Apply = context =>
+                    {
+                        var schema = context.SchemaProcessorContext.Schema;
+
+                        schema.Properties[context.PropertyKey].IsNullableRaw = false;
+
+                        if (schema.Properties[context.PropertyKey].Type.HasFlag(JsonObjectType.Null))
+                            schema.Properties[context.PropertyKey].Type &= ~JsonObjectType.Null; // Remove nullable
+
+                        var oneOfsWithReference = schema.Properties[context.PropertyKey].OneOf
+                                                        .Where(x => x.Reference != null)
+                                                        .ToList();
+
+                        if (oneOfsWithReference.Count == 1)
+                        {
+                            // Set the Reference directly instead and clear the OneOf collection
+                            schema.Properties[context.PropertyKey].Reference = oneOfsWithReference.Single();
+                            schema.Properties[context.PropertyKey].OneOf.Clear();
+                        }
+
+                        schema.Properties[context.PropertyKey].MinLength = 1;
+                    }
+                },
+                new FluentValidationRule("Length") {
+                    Matches = propertyValidator => propertyValidator is ILengthValidator,
+                    Apply = context =>
+                    {
+                        var schema = context.SchemaProcessorContext.Schema;
+
+                        var lengthValidator = (ILengthValidator)context.PropertyValidator;
+
+                        if (lengthValidator.Max > 0)
+                            schema.Properties[context.PropertyKey].MaxLength = lengthValidator.Max;
+
+                        if (lengthValidator.GetType() == typeof(MinimumLengthValidator<>)
+                            || lengthValidator.GetType() == typeof(ExactLengthValidator<>)
+                            || schema.Properties[context.PropertyKey].MinLength == null)
+                            schema.Properties[context.PropertyKey].MinLength = lengthValidator.Min;
+                    }
+                },
+                new FluentValidationRule("Pattern") {
+                    Matches = propertyValidator => propertyValidator is IRegularExpressionValidator,
+                    Apply = context =>
+                    {
+                        var regularExpressionValidator = (IRegularExpressionValidator)context.PropertyValidator;
+
+                        var schema = context.SchemaProcessorContext.Schema;
+                        schema.Properties[context.PropertyKey].Pattern = regularExpressionValidator.Expression;
+                    }
+                },
+                new FluentValidationRule("Comparison") {
+                    Matches = propertyValidator => propertyValidator is IComparisonValidator,
+                    Apply = context =>
+                    {
+                        var comparisonValidator = (IComparisonValidator)context.PropertyValidator;
+
+                        if (comparisonValidator.ValueToCompare.IsNumeric())
+                        {
+                            var valueToCompare = Convert.ToDecimal(comparisonValidator.ValueToCompare);
+                            var schema = context.SchemaProcessorContext.Schema;
+                            var schemaProperty = schema.Properties[context.PropertyKey];
+
+                            if (comparisonValidator.Comparison == Comparison.GreaterThanOrEqual)
+                                schemaProperty.Minimum = valueToCompare;
+                            else if (comparisonValidator.Comparison == Comparison.GreaterThan)
+                            {
+                                schemaProperty.Minimum = valueToCompare;
+                                schemaProperty.IsExclusiveMinimum = true;
+                            }
+                            else if (comparisonValidator.Comparison == Comparison.LessThanOrEqual)
+                                schemaProperty.Maximum = valueToCompare;
+                            else if (comparisonValidator.Comparison == Comparison.LessThan)
+                            {
+                                schemaProperty.Maximum = valueToCompare;
+                                schemaProperty.IsExclusiveMaximum = true;
+                            }
+                        }
+                    }
+                },
+                new FluentValidationRule("Between") {
+                    Matches = propertyValidator => propertyValidator is IBetweenValidator,
+                    Apply = context =>
+                    {
+                        var betweenValidator = (IBetweenValidator)context.PropertyValidator;
+                        var schema = context.SchemaProcessorContext.Schema;
+                        var schemaProperty = schema.Properties[context.PropertyKey];
+
+                        if (betweenValidator.From.IsNumeric())
+                        {
+                            if (betweenValidator.GetType().IsSubClassOfGeneric(typeof(ExclusiveBetweenValidator<,>)))
+                                schemaProperty.ExclusiveMinimum = Convert.ToDecimal(betweenValidator.From);
+                            else
+                                schemaProperty.Minimum = Convert.ToDecimal(betweenValidator.From);
+                        }
+
+                        if (betweenValidator.To.IsNumeric())
+                        {
+                            if (betweenValidator.GetType().IsSubClassOfGeneric(typeof(ExclusiveBetweenValidator<,>)))
+                                schemaProperty.ExclusiveMaximum = Convert.ToDecimal(betweenValidator.To);
+                            else
+                                schemaProperty.Maximum = Convert.ToDecimal(betweenValidator.To);
+                        }
+                    }
+                },
+                new FluentValidationRule("AspNetCoreCompatibleEmail") {
+                    Matches = propertyValidator => propertyValidator.GetType()
+                                                                    .IsSubClassOfGeneric(typeof(AspNetCoreCompatibleEmailValidator<>)),
+                    Apply = context =>
+                    {
+                        var schema = context.SchemaProcessorContext.Schema;
+                        schema.Properties[context.PropertyKey].Pattern = "^[^@]+@[^@]+$"; // [^@] All chars except @
+                    }
+                },
+            };
+}


### PR DESCRIPTION
Example:
![image](https://user-images.githubusercontent.com/16289034/168089673-858ecb84-90f8-4f3d-9cfa-152f919e1d5f.png)

**But it needs to be improved**, because it ignores validators with non-empty constructors (ScopedValidators)