### PR TITLE
Fixed Query<T> not working for some types & improved tests for Query<T>

### DIFF
--- a/Src/Library/Endpoint/Endpoint.cs
+++ b/Src/Library/Endpoint/Endpoint.cs
@@ -158,7 +158,7 @@ public abstract partial class Endpoint<TRequest, TResponse> : BaseEndpoint, ISer
     {
         if (HttpContext.Request.Query.TryGetValue(paramName, out var val))
         {
-            var res = typeof(T).ValueParser()?.Invoke(val);
+            var res = typeof(T).ValueParser()?.Invoke(val.ToString());
 
             if (res?.isSuccess is true)
                 return (T?)res?.value;

--- a/Tests/IntegrationTests/FastEndpoints.IntegrationTests/WebTests/MiscTestCases.cs
+++ b/Tests/IntegrationTests/FastEndpoints.IntegrationTests/WebTests/MiscTestCases.cs
@@ -452,12 +452,25 @@ public class MiscTestCases : EndToEndTestBase
     {
         var (rsp, res) = await GuestClient.GETAsync<
             EmptyRequest,
-            TestCases.RouteBindingInEpWithoutReq.Response>(
-            "/api/test-cases/ep-witout-req-query-param-binding-test?customerId=09809&otherId=12", new());
+            TestCases.QueryParamBindingInEpWithoutReq.Response>(
+            "/api/test-cases/ep-witout-req-query-param-binding-test" +
+            "?customerId=09809" +
+            "&otherId=12" + 
+            "&doubles=[123.45,543.21]" +
+            "&guids=[\"b01ec302-0adc-4a2b-973d-bbfe639ed9a5\",\"e08664a4-efd8-4062-a1e1-6169c6eac2ab\"]" +
+            "&ints=[1,2,3]" +
+            "&floaty=3.2", new());
 
         rsp?.StatusCode.Should().Be(HttpStatusCode.OK);
         res!.CustomerID.Should().Be(09809);
         res!.OtherID.Should().Be(12);
+        rsp?.StatusCode.Should().Be(HttpStatusCode.OK);
+        res?.Doubles.Length.Should().Be(2);
+        res?.Doubles[0].Should().Be(123.45);
+        res?.Guids.Count.Should().Be(2);
+        res?.Guids[0].Should().Be(Guid.Parse("b01ec302-0adc-4a2b-973d-bbfe639ed9a5"));
+        res?.Ints.Count().Should().Be(3);
+        res?.Ints.First().Should().Be(1);
     }
 
     [Fact]

--- a/Web/[Features]/TestCases/QueryParamBindingInEpWithoutReq/EpWithoutReqQueryParamBindingTest.cs
+++ b/Web/[Features]/TestCases/QueryParamBindingInEpWithoutReq/EpWithoutReqQueryParamBindingTest.cs
@@ -12,7 +12,7 @@ public class EpWithoutReqQueryParamBindingTest : EndpointWithoutRequest<Response
 
     public override Task HandleAsync(CancellationToken ct)
     {
-        return SendAsync(new Response 
+        return SendAsync(new() 
         {
             CustomerID = Query<int>("CustomerID"),
             OtherID = Query<int>("OtherID"),

--- a/Web/[Features]/TestCases/QueryParamBindingInEpWithoutReq/EpWithoutReqQueryParamBindingTest.cs
+++ b/Web/[Features]/TestCases/QueryParamBindingInEpWithoutReq/EpWithoutReqQueryParamBindingTest.cs
@@ -12,22 +12,32 @@ public class EpWithoutReqQueryParamBindingTest : EndpointWithoutRequest<Response
 
     public override Task HandleAsync(CancellationToken ct)
     {
-        return SendAsync(new()
+        return SendAsync(new Response 
         {
             CustomerID = Query<int>("CustomerID"),
-            OtherID = Query<int>("OtherID")
+            OtherID = Query<int>("OtherID"),
+            Doubles = Query<double[]>("Doubles"),
+            Guids = Query<List<Guid>>("Guids"),
+            Ints = Query<IEnumerable<int>>("Ints"),
+            Floaty = Query<float>("Floaty")
         });
     }
 }
 
 public class Response
 {
-    [BindFrom("customerId")]
     public int CustomerID { get; set; }
 
     /// <summary>
     /// optional other id
     /// </summary>
-    [BindFrom("otherID")]
     public int? OtherID { get; set; }
+
+    public double[] Doubles { get; set; }
+
+    public IEnumerable<int> Ints { get; set; }
+    
+    public List<Guid> Guids { get; set; }
+
+    public float Floaty { get; set; }
 }


### PR DESCRIPTION
Not sure why this got messed up this bad [MiscTestCases.cs](https://github.com/dj-nitehawk/FastEndpoints/compare/main...hoppel:main#diff-832c8bb65ad300a9dc7d8ef112ac61453217d68d154ee0bcd6080505eb75a2ac) , my actual changes were more query parameters inside `QueryParamReadingInEndpointWithoutRequest` to test them as well