### PR TITLE
Add correct integration of fluentvalidation rules with swagger

### DIFF
--- a/Src/Swagger/Extensions.cs
+++ b/Src/Swagger/Extensions.cs
@@ -20,6 +20,11 @@ namespace FastEndpoints.Swagger;
 public static class Extensions
 {
     /// <summary>
+    /// JsonNamingPolicy chosen for swagger
+    /// </summary>
+    public static JsonNamingPolicy? SelectedJsonNamingPolicy { get; private set; }
+    
+    /// <summary>
     /// enable support for FastEndpoints in swagger
     /// </summary>
     /// <param name="tagIndex">the index of the route path segment to use for tagging/grouping endpoints</param>
@@ -69,6 +74,7 @@ public static class Extensions
         services.AddOpenApiDocument(s =>
         {
             var stjOpts = new JsonSerializerOptions(Config.SerializerOpts);
+            SelectedJsonNamingPolicy = stjOpts.PropertyNamingPolicy;
             serializerSettings?.Invoke(stjOpts);
             s.SerializerSettings = SystemTextJsonUtilities.ConvertJsonOptionsToNewtonsoftSettings(stjOpts);
             s.EnableFastEndpoints(tagIndex, maxEndpointVersion, shortSchemaNames);


### PR DESCRIPTION
* Support dtos with inheritance
* Support more than one level child properties in validation rule
* Support Rule with SetValidator

Some complex scenarios for testing in https://github.com/wjax/FastEndpointsPlayground. Thanks to @NeskireDK

Fixes #127 