### PR TITLE
NullReferenceException with MVC APIs on swagger doc

### DIFF
--- a/Src/Swagger/OperationSecurityProcessor.cs
+++ b/Src/Swagger/OperationSecurityProcessor.cs
@@ -20,7 +20,7 @@ internal class OperationSecurityProcessor : IOperationProcessor
         if (epMeta is null)
             return true;
 
-        if (epMeta.OfType<AllowAnonymousAttribute>().Any() || !epMeta.OfType<AuthorizeAttribute>().Any())
+        if (epMeta.OfType<AllowAnonymousAttribute>().Any() || !epMeta.OfType<AuthorizeAttribute>().Any() || !epMeta.OfType<EndpointDefinition>().Any())
             return true;
 
         var epSchemes = epMeta.OfType<EndpointDefinition>().Single().AuthSchemes;

--- a/docs/wiki/Swagger-Support.html
+++ b/docs/wiki/Swagger-Support.html
@@ -102,7 +102,7 @@ using FastEndpoints.Swagger; //add this
 
 var builder = WebApplication.CreateBuilder();
 builder.Services.AddFastEndpoints();
-builder.Services.AddSwaggerDoc(); //add this
+builder.Services.AddSwaggerDocument(); //add this
 
 var app = builder.Build();
 app.UseAuthorization();
@@ -113,8 +113,8 @@ app.Run();
 </code></pre>
 <p>you can then visit <code>/swagger</code> or <code>/swagger/v1/swagger.json</code> to see swagger output.</p>
 <h2 id="configuration">configuration</h2>
-<p>swagger options can be configured as you'd typically do via the <code>AddSwaggerDoc()</code> method:</p>
-<pre><code class="lang-csharp">builder.Services.AddSwaggerDoc(settings =&gt;
+<p>swagger options can be configured as you'd typically do via the <code>AddSwaggerDocument()</code> method:</p>
+<pre><code class="lang-csharp">builder.Services.AddSwaggerDocument(settings =&gt;
 {
     settings.Title = &quot;My API&quot;;
     settings.Version = &quot;v1&quot;;


### PR DESCRIPTION
In my case, the ApiExplorer lists all API Routes, even classical MVC api routes. Upon loading /swagger/v1/swagger.json page, it throws an exception in the `.Single()` call in OperationSecurityProcessor.cs:26 because those APIs dont have an 'EndpointDefinition'. This PR checks this.

As i was testing my change, i noticed that the `builder.Services.AddSwaggerDoc` method is marked obsolete in the newest NSwag version, so i tried `builder.Services.AddSwaggerDocument` instead - and surprise - it fixed my initial problem.

You may close this PR, but i think, the implemented simple check does not hurt and you may accept it.