### PR TITLE
Reproduce and fix #147

### DIFF
--- a/Src/Library/Endpoint/Endpoint.Setup.cs
+++ b/Src/Library/Endpoint/Endpoint.Setup.cs
@@ -10,6 +10,7 @@ public abstract partial class Endpoint<TRequest, TResponse> : BaseEndpoint where
 {
     private static readonly Type tRequest = typeof(TRequest);
     private static readonly Type tResponse = typeof(TResponse);
+    private static readonly bool isEmptyRequest = Types.EmptyRequest.IsAssignableFrom(tRequest);
     private static readonly bool isPlainTextRequest = Types.IPlainTextRequest.IsAssignableFrom(tRequest);
 
     /// <summary>

--- a/Src/Library/Endpoint/Endpoint.Static.cs
+++ b/Src/Library/Endpoint/Endpoint.Static.cs
@@ -15,7 +15,11 @@ public abstract partial class Endpoint<TRequest, TResponse> : BaseEndpoint where
     {
         TRequest? req = default;
 
-        if (isPlainTextRequest)
+        if (isEmptyRequest)
+        {
+            req = new TRequest();
+        } 
+        else if (isPlainTextRequest)
         {
             req = await BindPlainTextBody(ctx.Request.Body);
         }
@@ -26,7 +30,7 @@ public abstract partial class Endpoint<TRequest, TResponse> : BaseEndpoint where
         }
         else
         {
-            req = new();
+            req = new TRequest();
         }
 
         BindFormValues(req, ctx.Request, failures, dontAutoBindForm);

--- a/Tests/IntegrationTests/FastEndpoints.IntegrationTests/WebTests/MiscTestCases.cs
+++ b/Tests/IntegrationTests/FastEndpoints.IntegrationTests/WebTests/MiscTestCases.cs
@@ -1,12 +1,14 @@
 ﻿using IntegrationTests.Shared.Fixtures;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Net.Http.Headers;
 using System.Net;
-using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Security.Cryptography;
+using System.Text;
 using TestCases.EventHandlingTest;
 using Xunit;
 using Xunit.Abstractions;
+using MediaTypeHeaderValue = System.Net.Http.Headers.MediaTypeHeaderValue;
 
 namespace FastEndpoints.IntegrationTests.WebTests;
 
@@ -62,6 +64,27 @@ public class MiscTestCases : EndToEndTestBase
         result.Should().Be("you sent xyz");
     }
 
+    [Fact]
+    public async Task EmptyRequest()
+    {
+        var endpointUrl = IEndpoint.TestURLFor<TestCases.EmptyRequestTest.EmptyRequestEndpoint>();
+        
+        var requestUri = new Uri(
+            AdminClient.BaseAddress!.ToString().TrimEnd('/') +
+            (endpointUrl.StartsWith('/') ? endpointUrl : "/" + endpointUrl)
+        );
+        
+        var message = new HttpRequestMessage {
+            Content = new StringContent(string.Empty, Encoding.UTF8, "application/json"),
+            Method = HttpMethod.Get,
+            RequestUri = requestUri
+        };
+        
+        var response = await AdminClient.SendAsync(message);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+    
     [Fact]
     public async Task HeaderMissing()
     {

--- a/Web/[Features]/TestCases/EmptyRequestTest/EmptyRequestEndpoint.cs
+++ b/Web/[Features]/TestCases/EmptyRequestTest/EmptyRequestEndpoint.cs
@@ -1,0 +1,12 @@
+﻿namespace TestCases.EmptyRequestTest;
+
+public class EmptyRequestEndpoint: Endpoint<EmptyRequest, EmptyResponse>
+{
+    public override void Configure()
+    {
+        Verbs(Http.GET);
+        Routes("/test-cases/empty-request-test");
+    }
+    
+    public async override Task HandleAsync(EmptyRequest req, CancellationToken ct) => await SendOkAsync(ct);
+}


### PR DESCRIPTION
Checks if the request type is `EmptyRequest` and skips any deserialization.