### PR TITLE
Patch: Exception when ApiControllers exist in the project

### DIFF
--- a/Src/Swagger/OperationSecurityProcessor.cs
+++ b/Src/Swagger/OperationSecurityProcessor.cs
@@ -23,7 +23,13 @@ internal class OperationSecurityProcessor : IOperationProcessor
         if (epMeta.OfType<AllowAnonymousAttribute>().Any() || !epMeta.OfType<AuthorizeAttribute>().Any())
             return true;
 
-        var epSchemes = epMeta.OfType<EndpointDefinition>().Single().AuthSchemes;
+        var schemesList = epMeta.OfType<EndpointDefinition>().SingleOrDefault();
+        if (schemesList == null)
+        {
+            throw new InvalidOperationsException($"Endpoint {context} missing an EndpointDefinition attribute for scheme {schemeName}");
+        }
+
+        var epSchemes = schemesList.AuthSchemes;
         if (epSchemes?.Contains(schemeName) == false)
             return true;
 


### PR DESCRIPTION
I migrated a project that also uses simple mvc api controllers (for culture setting etc). Unfortunally, swagger does not like that, maybe i'm just missing some documentation attributes there.

One solution would be to just `[ApiExplorerSettings(IgnoreApi = true)]` these Controllers. But the thrown exception is not really saying much information, as the "Single()" call just finds no results. So one does not know, which endpoint (controller) was causing the problem.

I changed that to check for null.

If you find, that the check in line 32 is not necessary (which captures the exception and allows the api controller to show up fine) even the exception message is now more clearly indicating, which endpoint/controller caused the problem.

I suggest to merge the PR without change.