### PR TITLE
Added DoesNotReturn attributes for throwing methods

### DIFF
--- a/Src/Library/Endpoint/Endpoint.Validation.cs
+++ b/Src/Library/Endpoint/Endpoint.Validation.cs
@@ -1,5 +1,6 @@
 ﻿using FluentValidation;
 using FluentValidation.Results;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 
 namespace FastEndpoints;
@@ -44,6 +45,7 @@ public abstract partial class Endpoint<TRequest, TResponse> : BaseEndpoint where
     /// <summary>
     /// interrupt the flow of handler execution and send a 400 bad request with error details if there are any validation failures in the current request. if there are no validation failures, execution will continue past this call.
     /// </summary>
+    [DoesNotReturn]
     protected void ThrowIfAnyErrors()
     {
         if (ValidationFailed) throw new ValidationFailureException();
@@ -53,6 +55,7 @@ public abstract partial class Endpoint<TRequest, TResponse> : BaseEndpoint where
     /// add a "GeneralError" to the validation failure list and send back a 400 bad request with error details immediately interrupting handler execution flow. if there are any vallidation failures, no execution will continue past this call.
     /// </summary>
     /// <param name="message">the error message</param>
+    [DoesNotReturn]
     protected void ThrowError(string message)
     {
         AddError(message);
@@ -64,6 +67,7 @@ public abstract partial class Endpoint<TRequest, TResponse> : BaseEndpoint where
     /// </summary>
     /// <param name="property">the property to add the error message for</param>
     /// <param name="errorMessage">the error message</param>
+    [DoesNotReturn]
     protected void ThrowError(Expression<Func<TRequest, object>> property, string errorMessage)
     {
         AddError(property, errorMessage);

--- a/Src/Library/Endpoint/Endpoint.Validation.cs
+++ b/Src/Library/Endpoint/Endpoint.Validation.cs
@@ -45,7 +45,6 @@ public abstract partial class Endpoint<TRequest, TResponse> : BaseEndpoint where
     /// <summary>
     /// interrupt the flow of handler execution and send a 400 bad request with error details if there are any validation failures in the current request. if there are no validation failures, execution will continue past this call.
     /// </summary>
-    [DoesNotReturn]
     protected void ThrowIfAnyErrors()
     {
         if (ValidationFailed) throw new ValidationFailureException();


### PR DESCRIPTION
[DoesNotReturn Attribute](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.codeanalysis.doesnotreturnattribute?view=net-6.0)
This fixes some issues with nullability and analyzers.

![image](https://user-images.githubusercontent.com/27558844/181645582-6eb28201-2273-48c1-832d-ead9d16695cd.png)

I ran into it doing this, which should be pretty common.

I couldn't run the tests, because I can't build the project. Something about "DiscoveredTypes" not existing, but I highly doubt this breaks anything.
